### PR TITLE
Upgrade to use the v1.1 api

### DIFF
--- a/tircd.pl
+++ b/tircd.pl
@@ -8,7 +8,7 @@
 
 use strict;
 use JSON::Any;
-use Net::Twitter::Lite::WithAPIv1_1;
+use Net::Twitter::Lite::WithAPIv1_1 0.12000;
 use Time::Local;
 use File::Glob ':glob';
 use IO::File;


### PR DESCRIPTION
Hey Tim,

As far as I can tell this seems to be the most recently updated codebase between google code and github.

Twitter turned off their v1 API the other day leaving only the v1.1 API to be used. I've switched Net::Twitter::Lite to use v1.1 and gone through the code and upgraded any deprecated API calls. This was fairly straight forward except for the !conversation bot command. The v1.0 related_results API endpoint was an undocumented endpoint and was deleted in v1.1. For now I've just set the twitter_conversation_related function to log a message and return.
